### PR TITLE
Add redux-like reducer to have `Project` globally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "eslint-plugin-react-hooks": "^4.5.0",
         "husky": "^7.0.4",
         "jest": "^27.4.1",
+        "jest-styled-components": "^7.0.8",
         "prettier": "^2.6.2",
         "react-beautiful-dnd-test-utils": "^4.1.1",
         "react-select-event": "^5.5.0",
@@ -27243,6 +27244,21 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/jest-styled-components": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-7.0.8.tgz",
+      "integrity": "sha512-0KE54d0yIzKcvtOv8eikyjG3rFRtKYUyQovaoha3nondtZzXYGB3bhsvYgEegU08Iry0ndWx2+g9f5ZzD4I+0Q==",
+      "dev": true,
+      "dependencies": {
+        "css": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "styled-components": ">= 5"
+      }
     },
     "node_modules/jest-util": {
       "version": "27.5.1",
@@ -58915,6 +58931,15 @@
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
+      }
+    },
+    "jest-styled-components": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-7.0.8.tgz",
+      "integrity": "sha512-0KE54d0yIzKcvtOv8eikyjG3rFRtKYUyQovaoha3nondtZzXYGB3bhsvYgEegU08Iry0ndWx2+g9f5ZzD4I+0Q==",
+      "dev": true,
+      "requires": {
+        "css": "^3.0.0"
       }
     },
     "jest-util": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "eslint-plugin-react-hooks": "^4.5.0",
     "husky": "^7.0.4",
     "jest": "^27.4.1",
+    "jest-styled-components": "^7.0.8",
     "prettier": "^2.6.2",
     "react-beautiful-dnd-test-utils": "^4.1.1",
     "react-select-event": "^5.5.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,11 @@
+import { useEffect, useReducer } from "react";
 import styled, { createGlobalStyle } from "styled-components";
 
-import ProjectDefinition from "./interfaces/Project";
+import projectReducer from "./store";
 import { GET_PROJECT_BY_ID } from "./api";
 import { useFetch } from "./hooks/useFetch";
+import { ProjectContext, ProjectReducerContext } from "./context/project";
+import ProjectDefinition from "./interfaces/Project";
 
 import LoadingSpinner from "./components/LoadingSpinner";
 import Project from "./components/Project";
@@ -16,17 +19,27 @@ body {
 `;
 
 export default function App(): JSX.Element {
-  const { data: project, isLoading } = useFetch<ProjectDefinition>(GET_PROJECT_BY_ID(1));
+  const { data: projectResponse, isLoading } = useFetch<ProjectDefinition>(GET_PROJECT_BY_ID(1));
+  const [project, dispatch] = useReducer(projectReducer.reducer, projectReducer.initialState);
+
+  useEffect(() => {
+    // once project has been fetched, it updates project which is used in the app as "state"
+    projectResponse && dispatch(projectReducer.updatedProject(projectResponse));
+  }, [projectResponse]);
 
   return (
     <Body>
       <GlobalStyle />
-      {isLoading || !project ? (
+      {isLoading ? (
         <Container>
           <LoadingSpinner size="M" />
         </Container>
       ) : (
-        <Project project={project} />
+        <ProjectReducerContext.Provider value={dispatch}>
+          <ProjectContext.Provider value={project}>
+            <Project />
+          </ProjectContext.Provider>
+        </ProjectReducerContext.Provider>
       )}
     </Body>
   );

--- a/src/components/EditableLabel/EditableLabel.tsx
+++ b/src/components/EditableLabel/EditableLabel.tsx
@@ -1,9 +1,12 @@
+import { useEffect } from "react";
 import { CSSProperties, FormEvent, KeyboardEvent, useRef, useState } from "react";
 import styled from "styled-components";
 
 export interface RootBodyProps {
   value?: string;
+  placeholder?: string;
   onBlur?: (value: string) => void;
+  onChange?: (inputStr: string) => void;
   className?: string;
   style?: CSSProperties;
 }
@@ -11,13 +14,19 @@ export interface RootBodyProps {
 export default function EditableLabel({
   value: initValue = "",
   onBlur = () => {},
+  onChange,
   ...props
 }: RootBodyProps): JSX.Element {
   const [value, setValue] = useState<string>(initValue);
   const ref = useRef<HTMLInputElement>(null);
 
+  useEffect(() => {
+    setValue(initValue);
+  }, [initValue]);
+
   const handleChange = (e: FormEvent<HTMLInputElement>) => {
     setValue(e.currentTarget.value);
+    onChange && onChange(e.currentTarget.value);
   };
 
   const handleBlur = () => {

--- a/src/components/EditableLabel/EditableLabel.tsx
+++ b/src/components/EditableLabel/EditableLabel.tsx
@@ -13,7 +13,7 @@ export interface RootBodyProps {
 export default function EditableLabel({
   value: initValue = "",
   onBlur = () => {},
-  onChange,
+  onChange = () => {},
   ...props
 }: RootBodyProps): JSX.Element {
   const [value, setValue] = useState<string>(initValue);
@@ -25,7 +25,7 @@ export default function EditableLabel({
 
   const handleChange = (e: FormEvent<HTMLInputElement>) => {
     setValue(e.currentTarget.value);
-    onChange && onChange(e.currentTarget.value);
+    onChange(e.currentTarget.value);
   };
 
   const handleBlur = () => {

--- a/src/components/EditableLabel/EditableLabel.tsx
+++ b/src/components/EditableLabel/EditableLabel.tsx
@@ -1,5 +1,4 @@
-import { useEffect } from "react";
-import { CSSProperties, FormEvent, KeyboardEvent, useRef, useState } from "react";
+import { useEffect, CSSProperties, FormEvent, KeyboardEvent, useRef, useState } from "react";
 import styled from "styled-components";
 
 export interface RootBodyProps {

--- a/src/components/EditableTicket/EditableTicket.tsx
+++ b/src/components/EditableTicket/EditableTicket.tsx
@@ -1,5 +1,4 @@
-import { useEffect } from "react";
-import { CSSProperties, FormEvent, KeyboardEvent, useRef, useState } from "react";
+import { useEffect, CSSProperties, FormEvent, KeyboardEvent, useRef, useState } from "react";
 import styled from "styled-components";
 
 import Card from "../Card";

--- a/src/components/Project/DnDColumnList.test.tsx
+++ b/src/components/Project/DnDColumnList.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 
+import { TestRendererWithContext } from "../../utils/testRendererWithContext";
 import { MOCKED_PROJECT } from "./constants";
 import DnDColumnList from "./DnDColumnList";
 
@@ -10,7 +11,7 @@ describe("<DnDColumnList />", () => {
     const secondColumnTitle = MOCKED_PROJECT.columns[1].name;
     const thirdColumnTitle = MOCKED_PROJECT.columns[2].name;
 
-    render(<DnDColumnList projectColumns={MOCKED_PROJECT.columns} />);
+    render(<DnDColumnList projectColumns={MOCKED_PROJECT.columns} />, { wrapper: TestRendererWithContext });
 
     const allColumnLabels = screen.getAllByLabelText("editable-label");
 

--- a/src/components/Project/Project.stories.tsx
+++ b/src/components/Project/Project.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentStory } from "@storybook/react";
+import { TestRendererWithContext } from "../../utils/testRendererWithContext";
 
-import { MOCKED_PROJECT } from "./constants";
 import Project from "./Project";
 
 export default {
@@ -8,10 +8,25 @@ export default {
   component: Project,
 };
 
-const Template: ComponentStory<typeof Project> = (args) => <Project {...args} />;
+// mock up fetch() to prevent storybook to crash because of node's version incompatibility
+global.fetch = () =>
+  Promise.resolve({
+    json: () =>
+      Promise.resolve({
+        status: 200,
+        body: {
+          id: 1,
+          name: "test",
+          sort: 1,
+          project: {},
+        },
+      }),
+  }) as unknown as Promise<Response>;
+
+const Template: ComponentStory<typeof Project> = () => (
+  <TestRendererWithContext>
+    <Project />
+  </TestRendererWithContext>
+);
 
 export const Basic = Template.bind({});
-
-Basic.args = {
-  project: MOCKED_PROJECT,
-};

--- a/src/components/Project/Project.test.tsx
+++ b/src/components/Project/Project.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
-
 import { MOCKED_PROJECT } from "./constants";
+
+import { TestRendererWithContext } from "../../utils/testRendererWithContext";
 import Project from "./Project";
 
 describe("<Project />", () => {
@@ -11,7 +12,7 @@ describe("<Project />", () => {
     const secondColumnTitle = MOCKED_PROJECT.columns[1].name;
     const thirdColumnTitle = MOCKED_PROJECT.columns[2].name;
 
-    render(<Project project={MOCKED_PROJECT} />);
+    render(<Project />, { wrapper: TestRendererWithContext });
 
     const allColumnLabels = screen.getAllByLabelText("editable-label");
 

--- a/src/components/Project/Project.tsx
+++ b/src/components/Project/Project.tsx
@@ -1,19 +1,20 @@
 import styled from "styled-components";
-import { Add, FilterList, FlashOn, GroupAdd, MoreHoriz, People, StarBorder, TableChart } from "@material-ui/icons";
+import { FilterList, FlashOn, GroupAdd, MoreHoriz, People, StarBorder, TableChart } from "@material-ui/icons";
 
+import ProjectDefinition from "../../interfaces/Project";
 import { UPDATE_PROJECT_TITLE } from "../../api";
 import { useMutation } from "../../hooks/useMutation";
-import ProjectDefinition from "../../interfaces/Project";
+import { useTypeSafeContext } from "../../hooks/useTypeSafeContext";
+import { ProjectContext } from "../../context/project";
+
 import _Button from "../Button";
 import IconButton from "../IconButton";
 import EditableLabel from "../EditableLabel";
 import DnDColumnList from "./DnDColumnList";
+import AdditionColumn from "../AdditionColumn";
 
-export interface Props {
-  project: ProjectDefinition;
-}
-
-export default function Project({ project }: Props): JSX.Element {
+export default function Project(): JSX.Element {
+  const project = useTypeSafeContext(ProjectContext);
   const { call } = useMutation<ProjectDefinition>(UPDATE_PROJECT_TITLE(project.id), "PUT");
 
   const handleBlur = async (value: string) => {
@@ -28,27 +29,19 @@ export default function Project({ project }: Props): JSX.Element {
         <Header>
           <HeaderLeft>
             <Button title="Board" icon={<TableChart />} data-testid="boardButton" />
-
             <EditableTitle value={project.name} onBlur={handleBlur} />
-
             <StarButton data-testid="starButton">
               <StarBorder />
             </StarButton>
-
             <Button title="test" data-testid="testButton" />
-
             <Button title="Workspace visible" icon={<People />} data-testid="workSpaceButton" />
-
             <ShareButton title="Share" icon={<GroupAdd />} data-testid="shareButton" />
           </HeaderLeft>
 
           <HeaderRight>
             <Button title="Power-Ups" data-testid="powerUpsButton" />
-
             <Button title="Automation" icon={<FlashOn />} data-testid="automationButton" />
-
             <Button title="Filter" icon={<FilterList />} data-testid="filterButton" />
-
             <Button title="Show manu" icon={<MoreHoriz />} data-testid="showMenuButton" />
           </HeaderRight>
         </Header>

--- a/src/components/Project/Project.tsx
+++ b/src/components/Project/Project.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { FilterList, FlashOn, GroupAdd, MoreHoriz, People, StarBorder, TableChart } from "@material-ui/icons";
+import { FilterList, FlashOn, GroupAdd, MoreHoriz, People, StarBorder, TableChart, Add } from "@material-ui/icons";
 
 import ProjectDefinition from "../../interfaces/Project";
 import { UPDATE_PROJECT_TITLE } from "../../api";
@@ -11,7 +11,6 @@ import _Button from "../Button";
 import IconButton from "../IconButton";
 import EditableLabel from "../EditableLabel";
 import DnDColumnList from "./DnDColumnList";
-import AdditionColumn from "../AdditionColumn";
 
 export default function Project(): JSX.Element {
   const project = useTypeSafeContext(ProjectContext);

--- a/src/context/project.ts
+++ b/src/context/project.ts
@@ -1,0 +1,7 @@
+import { createContext, Dispatch } from "react";
+
+import projectReducer from "../store/index";
+import ProjectDefinition from "../interfaces/Project";
+
+export const ProjectReducerContext = createContext<Dispatch<projectReducer.PassedActions> | undefined>(undefined);
+export const ProjectContext = createContext<ProjectDefinition | undefined>(undefined);

--- a/src/hooks/useTypeSafeContext.test.tsx
+++ b/src/hooks/useTypeSafeContext.test.tsx
@@ -1,0 +1,42 @@
+import { createContext } from "react";
+import { render, screen } from "@testing-library/react";
+import { useTypeSafeContext } from "./useTypeSafeContext";
+
+const MockedContext = createContext<string | undefined>(undefined);
+
+// mock function to test `useTypeSafeContext()`. Renderes passed context value if it HAS value
+function MockedContextComponent(): JSX.Element {
+  const contextValue = useTypeSafeContext(MockedContext);
+  return <div>{contextValue}</div>;
+}
+
+describe("useTypeSafeContext()", () => {
+  test("Passed valid context - should render a component that contains passed value via context", () => {
+    // arrange
+    const mockedContextValue = "Lorem Ipsum";
+
+    render(
+      <MockedContext.Provider value={mockedContextValue}>
+        <MockedContextComponent />
+      </MockedContext.Provider>,
+    );
+
+    // assert
+    expect(screen.getByText(mockedContextValue)).toBeTruthy();
+  });
+
+  test("Passed undefined context - should throw an error that indicates the context is broken", () => {
+    // arrange
+    const mockedContextValue = undefined;
+    const expectedErrorMessage = "useContext must be inside a Provider with a value";
+
+    // Assert
+    expect(() =>
+      render(
+        <MockedContext.Provider value={mockedContextValue}>
+          <MockedContextComponent />
+        </MockedContext.Provider>,
+      ),
+    ).toThrow(new Error(expectedErrorMessage));
+  });
+});

--- a/src/hooks/useTypeSafeContext.ts
+++ b/src/hooks/useTypeSafeContext.ts
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+
+/**
+ * equivalent to `useContext` from react - but using this hook removes null check on every values from context.
+ * Use this one instead of the one from React
+ */
+export function useTypeSafeContext<TContext>(passedContext: React.Context<TContext | undefined>): TContext {
+  const context = useContext(passedContext);
+  if (!context) throw new Error("useContext must be inside a Provider with a value");
+  return context;
+}

--- a/src/interfaces/Column.ts
+++ b/src/interfaces/Column.ts
@@ -1,4 +1,13 @@
+import Project from "./Project";
 import Ticket from "./Ticket";
+
+/** Response shape from the server */
+export interface ColumnResponse {
+  id: number;
+  name: string;
+  sort: number;
+  project: Project;
+}
 
 export default interface Column {
   id: number;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,1 @@
+export * as default from "./project";

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -1,0 +1,73 @@
+import Column from "../interfaces/Column";
+import Project from "../interfaces/Project";
+
+// state
+const initialState: Project = {
+  id: -1,
+  name: "",
+  columns: [],
+};
+
+// actions
+const ACTIONS = {
+  UPDATED_PROJECT: "@PROJECT/UPDATED_PROJECT",
+  UPDATED_COLUMN: "@PROJECT/UPDATED_COLUMN",
+  ADDED_NEW_COLUMN: "@PROJECT/ADD_NEW_COLUMN",
+} as const;
+
+/**
+ * An action to update project. It will replace entire project with passed value
+ */
+const updatedProject = (project: Project) =>
+  ({
+    type: ACTIONS.UPDATED_PROJECT,
+    payload: project,
+  } as const);
+
+/**
+ * An action to update column. It will replace entire column with passed value
+ */
+const updatedColumn = (column: Column[]) =>
+  ({
+    type: ACTIONS.UPDATED_COLUMN,
+    payload: column,
+  } as const);
+
+/**
+ * An action to add new column to the end of `column` array of project
+ */
+const addedNewColumn = (newColumn: Column) =>
+  ({
+    type: ACTIONS.ADDED_NEW_COLUMN,
+    payload: newColumn,
+  } as const);
+
+// reducers
+
+/**
+ * Types for actions passed to the reducer.
+ * Make sure to add one here when you create new action to make reducer smart with typescript
+ */
+type PassedActions =
+  | ReturnType<typeof addedNewColumn>
+  | ReturnType<typeof updatedProject>
+  | ReturnType<typeof updatedColumn>;
+
+/**
+ * Reducer of the Project store. You shouldn't need this function to be imported when you want to change state in context.
+ * import an action and use it with `dispatch` which is also passed by context.
+ */
+function reducer(state: Project, action: PassedActions): Project {
+  switch (action.type) {
+    case ACTIONS.UPDATED_PROJECT:
+      return { ...state, ...action.payload };
+    case ACTIONS.ADDED_NEW_COLUMN:
+      return { ...state, columns: [...state.columns, action.payload] };
+    case ACTIONS.UPDATED_COLUMN:
+      return { ...state, columns: action.payload };
+    default:
+      return { ...state };
+  }
+}
+
+export { initialState, ACTIONS, PassedActions, addedNewColumn, updatedColumn, updatedProject, reducer };

--- a/src/utils/testRendererWithContext.tsx
+++ b/src/utils/testRendererWithContext.tsx
@@ -1,0 +1,17 @@
+import { useReducer } from "react";
+import { ProjectContext, ProjectReducerContext } from "../context/project";
+import { MOCKED_PROJECT } from "../components/Project/constants";
+import projectReducer from "../store";
+
+/**
+ * A test renderer to pass mocked project via context. Use this component if your component grabs value from context
+ */
+export function TestRendererWithContext({ children }: { children: JSX.Element | JSX.Element[] }): JSX.Element {
+  const [project, dispatch] = useReducer(projectReducer.reducer, MOCKED_PROJECT);
+
+  return (
+    <ProjectReducerContext.Provider value={dispatch}>
+      <ProjectContext.Provider value={project}>{children}</ProjectContext.Provider>
+    </ProjectReducerContext.Provider>
+  );
+}


### PR DESCRIPTION
### Ticket
https://github.com/ryonryon/trello-clone/issues/60

### Description
This is one of a series of changes for `newColumn` functionality ticket. For this component, in order to have `Project` in global scope, this PR is focused on the context & reducer(store) part. I got inspired by React's documentation's suggestion to use `useReducer` + `ContextAPI`. This change really looks like Redux but is done by only React APIs. I hope you are familiar with the redux ecosystem.

### Why not use state management library like Redux?
I wanted to keep the change minimal because these libraries tend to introduce a decent amount of boilerplates which costs us some time to set up. Since this app only needs `Project` to be global so far, I've just decided to follow React's recommendation which follows Redux's action-to-reducer pattern, so the abstraction can easily be applied to Redux library even if we decided to go with it.

Documentation's recommendation: https://reactjs.org/docs/hooks-faq.html#how-to-avoid-passing-callbacks-down
